### PR TITLE
Remove interpolation expressions

### DIFF
--- a/multiple-servers/mainserver.tf
+++ b/multiple-servers/mainserver.tf
@@ -1,37 +1,37 @@
 provider "gridscale" {}
 
-resource "gridscale_server" "caching-server"{
-  name = "caching-server"
-  cores = 1
+resource "gridscale_server" "caching-server" {
+  name   = "caching-server"
+  cores  = 1
   memory = 2
   storage {
-    bootdevice = true
-    object_uuid = "${gridscale_storage.caching-storage.id}"
+    bootdevice  = true
+    object_uuid = gridscale_storage.caching-storage.id
   }
   network {
-    object_uuid = "${gridscale_network.webserver-network.id}"
+    object_uuid = gridscale_network.webserver-network.id
   }
-  ipv4 = "${gridscale_ipv4.caching-server-ip.id}"
+  ipv4  = gridscale_ipv4.caching-server-ip.id
   power = true
 }
 
-resource "gridscale_storage" "caching-storage"{
-  name = "caching-server-storage"
+resource "gridscale_storage" "caching-storage" {
+  name     = "caching-server-storage"
   capacity = 10
   template {
-    template_uuid = "${data.gridscale_template.ubuntu.id}"
-    sshkeys = [ "${gridscale_sshkey.sshkey.id}" ]
+    template_uuid = data.gridscale_template.ubuntu.id
+    sshkeys       = [gridscale_sshkey.sshkey.id]
   }
 }
 
-resource "gridscale_network" "webserver-network"{
+resource "gridscale_network" "webserver-network" {
   name = "websever-network"
 }
 
-resource "gridscale_ipv4" "caching-server-ip"{}
+resource "gridscale_ipv4" "caching-server-ip" {}
 
-resource "gridscale_sshkey" "sshkey"{
-  name = "complete-sshkey"
+resource "gridscale_sshkey" "sshkey" {
+  name   = "complete-sshkey"
   sshkey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDPYHDe/rzR6tb2y6TI1fnGRbpac9dAb8i1RP1tPS3ulG3BSR5VOSQGUvpy7VB71DH/VTBLWQz4Y4J+r5hDJbuNIvNd8jInCEWKgsqC9oFECBGPmOWEr44p+Hsje70sh6Nj34xYjdi6BBc2S+7/KpFzT0tybQTerGcAwztrESTa7iOsEazr6j+nJyhWXaWvHR1U3rC1cKM4QQWQCQHYhCmVGpdiYcFj3JKYjFXgArryZSz0EetWqw17vePD8BI0xawVIZO0f9RdqJ9eYh1vW/k1Gg30qpuVSADNZDMvgkfJnRD+SLjKJBYRdPx61fsmLm+6eL0NLXYVDmnTElpbRhhD wouter@gridscales-MacBook-Air.local"
 }
 

--- a/multiple-servers/webservers.tf
+++ b/multiple-servers/webservers.tf
@@ -1,65 +1,65 @@
-resource "gridscale_server" "webserver1"{
-  name = "webserver1"
-  cores = 1
+resource "gridscale_server" "webserver1" {
+  name   = "webserver1"
+  cores  = 1
   memory = 1
   storage {
-    bootdevice = true
-    object_uuid = "${gridscale_storage.webserver1-storage.id}"
+    bootdevice  = true
+    object_uuid = gridscale_storage.webserver1-storage.id
   }
   network {
-    object_uuid = "${gridscale_network.webserver-network.id}"
+    object_uuid = gridscale_network.webserver-network.id
   }
 }
 
-resource "gridscale_storage" "webserver1-storage"{
-  name = "websever1-storage"
+resource "gridscale_storage" "webserver1-storage" {
+  name     = "websever1-storage"
   capacity = 10
   template {
-    template_uuid = "${data.gridscale_template.ubuntu.id}"
-    sshkeys = [ "${gridscale_sshkey.sshkey.id}" ]
+    template_uuid = data.gridscale_template.ubuntu.id
+    sshkeys       = [gridscale_sshkey.sshkey.id]
   }
 }
 
-resource "gridscale_server" "webserver2"{
-  name = "webserver2"
-  cores = 1
+resource "gridscale_server" "webserver2" {
+  name   = "webserver2"
+  cores  = 1
   memory = 1
   storage {
-    bootdevice = true
-    object_uuid = "${gridscale_storage.webserver2-storage.id}"
+    bootdevice  = true
+    object_uuid = gridscale_storage.webserver2-storage.id
   }
   network {
-    object_uuid = "${gridscale_network.webserver-network.id}"
+    object_uuid = gridscale_network.webserver-network.id
   }
 }
 
-resource "gridscale_storage" "webserver2-storage"{
-  name = "websever2-storage"
+resource "gridscale_storage" "webserver2-storage" {
+  name     = "websever2-storage"
   capacity = 10
   template {
-    template_uuid = "${data.gridscale_template.ubuntu.id}"
-    sshkeys = [ "${gridscale_sshkey.sshkey.id}" ]
+    template_uuid = data.gridscale_template.ubuntu.id
+    sshkeys       = [gridscale_sshkey.sshkey.id]
   }
 }
 
-resource "gridscale_server" "webserver3"{
-  name = "webserver3"
-  cores = 1
+resource "gridscale_server" "webserver3" {
+  name   = "webserver3"
+  cores  = 1
   memory = 1
   storage {
-    bootdevice = true
-    object_uuid = "${gridscale_storage.webserver3-storage.id}"
+    bootdevice  = true
+    object_uuid = gridscale_storage.webserver3-storage.id
   }
   network {
-    object_uuid = "${gridscale_network.webserver-network.id}"
+    object_uuid = gridscale_network.webserver-network.id
   }
 }
 
-resource "gridscale_storage" "webserver3-storage"{
-  name = "websever3-storage"
+resource "gridscale_storage" "webserver3-storage" {
+  name     = "websever3-storage"
   capacity = 10
   template {
-    template_uuid = "${data.gridscale_template.ubuntu.id}"
-    sshkeys = [ "${gridscale_sshkey.sshkey.id}" ]
+    template_uuid = data.gridscale_template.ubuntu.id
+    sshkeys       = [gridscale_sshkey.sshkey.id]
   }
 }

--- a/single-server/complete/server.tf
+++ b/single-server/complete/server.tf
@@ -1,40 +1,40 @@
 provider "gridscale" {}
 
-resource "gridscale_server" "server"{
-  name = "demo-complete-server"
-  cores = 1
+resource "gridscale_server" "server" {
+  name   = "demo-complete-server"
+  cores  = 1
   memory = 2
   storage {
-    bootdevice = true
-    object_uuid = "${gridscale_storage.storage.id}"
+    bootdevice  = true
+    object_uuid = gridscale_storage.storage.id
   }
   network {
-    object_uuid = "${gridscale_network.network.id}"
+    object_uuid = gridscale_network.network.id
   }
-  ipv4 = "${gridscale_ipv4.ip.id}"
+  ipv4  = gridscale_ipv4.ip.id
   power = true
 }
 
-resource "gridscale_storage" "storage"{
-  name = "demo-complete-storage"
+resource "gridscale_storage" "storage" {
+  name     = "demo-complete-storage"
   capacity = 10
   template {
     #template_uuid = "4db64bfc-9fb2-4976-80b5-94ff43b1233a"
-    template_uuid = "${data.gridscale_template.ubuntu.id}"
-    sshkeys = [ "${gridscale_sshkey.sshkey.id}" ]
+    template_uuid = data.gridscale_template.ubuntu.id
+    sshkeys       = [gridscale_sshkey.sshkey.id]
   }
 }
 
-resource "gridscale_network" "network"{
+resource "gridscale_network" "network" {
   name = "demo-complete-network"
 }
 
-resource "gridscale_ipv4" "ip"{
+resource "gridscale_ipv4" "ip" {
   name = "demo-complete-ip"
 }
 
-resource "gridscale_sshkey" "sshkey"{
-  name = "demo-complete-sshkey"
+resource "gridscale_sshkey" "sshkey" {
+  name   = "demo-complete-sshkey"
   sshkey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDPYHDe/rzR6tb2y6TI1fnGRbpac9dAb8i1RP1tPS3ulG3BSR5VOSQGUvpy7VB71DH/VTBLWQz4Y4J+r5hDJbuNIvNd8jInCEWKgsqC9oFECBGPmOWEr44p+Hsje70sh6Nj34xYjdi6BBc2S+7/KpFzT0tybQTerGcAwztrESTa7iOsEazr6j+nJyhWXaWvHR1U3rC1cKM4QQWQCQHYhCmVGpdiYcFj3JKYjFXgArryZSz0EetWqw17vePD8BI0xawVIZO0f9RdqJ9eYh1vW/k1Gg30qpuVSADNZDMvgkfJnRD+SLjKJBYRdPx61fsmLm+6eL0NLXYVDmnTElpbRhhD wouter@gridscales-MacBook-Air.local"
 }
 

--- a/single-server/provisioner/server.tf
+++ b/single-server/provisioner/server.tf
@@ -1,5 +1,4 @@
-provider "gridscale" {
-}
+provider "gridscale" {}
 
 resource "gridscale_server" "server" {
   name = "demo-complete-provisioner"
@@ -25,12 +24,12 @@ resource "gridscale_storage" "storage" {
 }
 
 resource "local_file" "ansible_inventory" {
-  content = "${gridscale_server.server.name} ansible_host=${gridscale_ipv4.ip.ip}"
+  content = gridscale_server.server.name ansible_host=gridscale_ipv4.ip.ip
   filename = "hosts"
 }
 
 resource "null_resource" "storage_provisioner" {
-  
+
   triggers = {
     storage_id = gridscale_storage.storage.id
   }
@@ -44,7 +43,7 @@ resource "null_resource" "storage_provisioner" {
       timeout = "2m"
     }
   }
- 
+
   provisioner "local-exec" {
     command = "ansible-playbook -i hosts main.yml"
   }

--- a/single-server/with-storage/server.tf
+++ b/single-server/with-storage/server.tf
@@ -1,16 +1,16 @@
-provider "gridscale" { }
+provider "gridscale" {}
 
-resource "gridscale_server" "server"{
-	name = "demo-server"
-	cores = 1
-	memory = 2
-	storage{
-		bootdevice = true
-		object_uuid = "${gridscale_storage.storage.id}"
-	}
+resource "gridscale_server" "server" {
+  name   = "demo-server"
+  cores  = 1
+  memory = 2
+  storage {
+    bootdevice  = true
+    object_uuid = gridscale_storage.storage.id
+  }
 }
 
-resource "gridscale_storage" "storage"{
-	name = "demo-storage"
-	capacity = 11
+resource "gridscale_storage" "storage" {
+  name     = "demo-storage"
+  capacity = 11
 }


### PR DESCRIPTION
Remove interpolation expressions from code and docs. Interpolation expressions, such as `"${gridscale_storage.caching-storage.id}"` are deprecated. These should be replaced by expressions like `gridscale_storage.caching-storage.id`.

Fixes issue #3.